### PR TITLE
New 'analysis' dependency with conda-pack

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_python3.7:
         CONFIG: linux_python3.7
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: nsls2/nsls2forge:latest
     maxParallel: 8
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -3,7 +3,7 @@ channel_sources:
 channel_targets:
 - nsls2forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- nsls2/nsls2forge:latest
 numpy:
 - '1.14'
 pin_run_as_build:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,3 +5,7 @@ channel_targets:
 python:
   - 3.6
   - 3.7
+docker_image:
+  - nsls2/nsls2forge:latest
+cuda_compiler_version:
+  - None

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,14 +67,7 @@ test:
     - sixtools
   commands:
     # Fail if the "conda-forge" channel is in the list of channels.
-    
-    # The conda-forge channel does not appear when building locally using a
-    # different Docker image.
-    # (host) $ docker run -it --rm -v $PWD:/build nsls2/debian-with-miniconda:v0.1.2 bash
-    # $ conda create -n test -c nsls2forge -c defaults --override-channels analysis=2020C2.0 chxtools csxtools edrixs eiger-io hxntools isstools py4xs sixtools
-    
-    # TODO: make it working again in the cloud.
-    # - check-results -t channels -f conda-forge
+    - check-results -t channels -f conda-forge
 
     # Fail if versions of the packages are not as expected minimum ones.
     - check-results -t version -p bluesky     -e 1.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<37 or not linux]
 
 requirements:
@@ -16,7 +16,7 @@ requirements:
     - python
   run:
     - python
-    - analysis ==2020C2.0=*_3
+    - analysis ==2020C2.0=*_4
     - chxtools
     - csxtools
     - edrixs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,6 +76,8 @@ test:
     - python -V
     - ipython -V
     - nexpy --help
+    - conda-pack --help
+    - conda-unpack --help
 
 about:
   home: https://github.com/NSLS-II

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -77,7 +77,6 @@ test:
     - ipython -V
     - nexpy --help
     - conda-pack --help
-    - conda-unpack --help
 
 about:
   home: https://github.com/NSLS-II

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,6 @@ test:
   commands:
     # Fail if the "conda-forge" channel is in the list of channels.
     - check-results -t channels -f conda-forge
-
     # Fail if versions of the packages are not as expected minimum ones.
     - check-results -t version -p bluesky     -e 1.6
     - check-results -t version -p databroker  -e 1.0


### PR DESCRIPTION
Also, uses the https://hub.docker.com/repository/docker/nsls2/nsls2forge Docker image for builds which "respects" the list of channels for the feedstocks (i.e., no `conda-forge` channel in the build/test steps).