### PR TITLE
nsls2-analysis 2020-2.0rc5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About nsls2-analysis
 
 Home: https://github.com/NSLS-II
 
-Package license: BSD 3-Clause
+Package license: BSD-3-Clause
 
 Feedstock license: BSD-3-Clause
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,10 +2,10 @@ channel_sources:
   - nsls2forge,defaults
 channel_targets:
   - nsls2forge main
-python:
-  - 3.6
-  - 3.7
 docker_image:
   - nsls2/nsls2forge:latest
 cuda_compiler_version:
   - None
+python:
+  - 3.6
+  - 3.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
-  number: 4
+  number: 5
   skip: true  # [py<37 or not linux]
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - csxtools
     - edrixs
     - eiger-io
-    - hxntools
+    - hxntools >=0.4.3
     - ispyb
     - isstools
     - nslsii  # needed for transforms at CSX


### PR DESCRIPTION
Fixes the `hxntools` incompatibility with `ophyd` 1.5.x.