### PR TITLE
nsls2-analysis 2021-1.1

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,5 +17,7 @@ python:
 target_platform:
 - linux-64
 zip_keys:
+- - cdt_name
+  - docker_image
 - - python
   - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
     - python
   run:
     - python
-    - analysis ==2021C1.0=*_0
+    - analysis ==2021C1.1
     - chxtools
     - csxtools
     - edrixs


### PR DESCRIPTION
Uses https://github.com/nsls-ii-forge/analysis-feedstock/pull/37.